### PR TITLE
add @timestamp to log, iso8601 format

### DIFF
--- a/lib/docker-fluent-logger/payload.rb
+++ b/lib/docker-fluent-logger/payload.rb
@@ -8,6 +8,7 @@ module DockerFluentLogger
     def append_info_to_payload(payload)
       super
 
+      payload[:@timestamp] = Time.now.utc.strftime('%Y-%m-%dT%X%z').insert(22, ':')
       payload[:uuid] = request.uuid
       payload[:url] = request.url
       payload[:referer]  = request.referer


### PR DESCRIPTION
`utc.iso8601`とする方法もありましたが、TimeZone部分がUTCだと`Z`になります。
iso8601としては合っているんですが、nginxで`+00:00`表記になるので合わせました。